### PR TITLE
New drive ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ bin/
 
 # Simulation GUI and other tools window save file
 *-window.json
+networktables.ini.bak

--- a/networktables.ini
+++ b/networktables.ini
@@ -1,0 +1,18 @@
+    [NetworkTables Storage 3.0]
+    double "/Config/CanCoder CanId FL"=50
+    double "/Config/CanCoder CanId FR"=49
+    double "/Config/CanCoder CanId RL"=59
+    double "/Config/CanCoder CanId RR"=40
+    double "/Config/DriveMotor CanId FL"=32
+    double "/Config/DriveMotor CanId FR"=28
+    double "/Config/DriveMotor CanId RL"=38
+    double "/Config/DriveMotor CanId RR"=21
+    double "/Config/Shooter CanId"=24
+    double "/Config/TurnMotor CanId FL"=30
+    double "/Config/TurnMotor CanId FR"=29
+    double "/Config/TurnMotor CanId RL"=39
+    double "/Config/TurnMotor CanId RR"=40
+    double "/Config/ZeroAngle FL"=92.5
+    double "/Config/ZeroAngle FR"=-3.39
+    double "/Config/ZeroAngle RL"=164
+    double "/Config/ZeroAngle RR"=-81.8

--- a/simgui.json
+++ b/simgui.json
@@ -14,6 +14,18 @@
       "/LiveWindow/Ungrouped/PIDController[7]": "PIDController",
       "/LiveWindow/Ungrouped/PIDController[8]": "PIDController",
       "/LiveWindow/Ungrouped/Scheduler": "Scheduler",
+      "/LiveWindow/Ungrouped/Talon FX [0]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [1]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [21]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [28]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [2]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [32]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [38]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [3]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [4]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [5]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [6]": "Motor Controller",
+      "/LiveWindow/Ungrouped/Talon FX [7]": "Motor Controller",
       "/SmartDashboard/Auto Choices": "String Chooser",
       "/SmartDashboard/Drive FR 0.5mps": "Command",
       "/SmartDashboard/Drive Forward 0.5mps": "Command",
@@ -33,10 +45,7 @@
     }
   },
   "NetworkTables": {
-    "FMSInfo": {
-      "open": true
-    },
-    "SmartDashboard": {
+    "Config": {
       "open": true
     }
   }

--- a/src/main/java/frc/robot/Configuration.java
+++ b/src/main/java/frc/robot/Configuration.java
@@ -1,0 +1,116 @@
+package frc.robot;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+public class Configuration {
+    private static String[] wheelIds = new String[] {"FL", "FR", "RL", "RR"};
+    private static NetworkTable table;
+    private static final String SHOOTER_KEY = "Shooter CanId";
+    private static final String DRIVEMOTOR_KEY = "DriveMotor CanId ";
+    private static final String TURNMOTOR_KEY = "TurnMotor CanId ";
+    private static final String CANCODER_KEY = "CanCoder CanId ";
+    private static final String ZEROANGLE_KEY = "ZeroAngle ";
+
+    public static String GetWheelName(byte whl) {
+        if (whl < 0 || whl > 3)
+            return "";
+        return wheelIds[whl];
+    }
+
+    public static void SetPersistentKeys() {
+        loadTable();
+
+        makePeristent(table.getEntry(SHOOTER_KEY), 24);
+        for(byte i=0; i<4; i++) {
+            String id = GetWheelName(i);
+            makePeristent(table.getEntry(DRIVEMOTOR_KEY + id), i);
+            makePeristent(table.getEntry(TURNMOTOR_KEY + id), i+10);
+            makePeristent(table.getEntry(CANCODER_KEY + id), i+20);
+            makePeristent(table.getEntry(ZEROANGLE_KEY + id), 0);
+        }
+    }
+
+    public static int GetDriveMotorId(byte whl) {
+        loadTable();
+        return (int)table.getEntry(DRIVEMOTOR_KEY + GetWheelName(whl)).getDouble(0);
+    }
+
+    public static int GetTurnMotorId(byte whl) {
+        loadTable();
+        return (int)table.getEntry(TURNMOTOR_KEY + GetWheelName(whl)).getDouble(0);
+    }
+
+    public static int GetCanCoderId(byte whl) {
+        loadTable();
+        return (int)table.getEntry(CANCODER_KEY + GetWheelName(whl)).getDouble(0);
+    }
+
+    public static double GetZeroAngle(byte whl) {
+        loadTable();
+        return table.getEntry(ZEROANGLE_KEY + GetWheelName(whl)).getDouble(0);
+    }
+
+    public static int GetShooterId() {
+        loadTable();
+        return (int)table.getEntry(SHOOTER_KEY).getDouble(0);
+    }
+
+    private static void loadTable() {
+        if(table == null) {
+            table = NetworkTableInstance.getDefault().getTable("Config");
+        }
+    }
+
+    private static void makePeristent(NetworkTableEntry entry, Number value) {
+        if(!entry.isPersistent()) {
+            entry.setNumber(value);
+            entry.setPersistent();
+        }
+    }
+
+    /*
+    Sample Tables:
+
+    Swerve Bot
+    [NetworkTables Storage 3.0]
+    double "/Config/CanCoder CanId FL"=3
+    double "/Config/CanCoder CanId FR"=0
+    double "/Config/CanCoder CanId RL"=1
+    double "/Config/CanCoder CanId RR"=2
+    double "/Config/DriveMotor CanId FL"=7
+    double "/Config/DriveMotor CanId FR"=5
+    double "/Config/DriveMotor CanId RL"=4
+    double "/Config/DriveMotor CanId RR"=6
+    double "/Config/Shooter CanId"=0
+    double "/Config/TurnMotor CanId FL"=8
+    double "/Config/TurnMotor CanId FR"=9
+    double "/Config/TurnMotor CanId RL"=11
+    double "/Config/TurnMotor CanId RR"=10
+    double "/Config/ZeroAngle FL"=-6.1
+    double "/Config/ZeroAngle FR"=47.9
+    double "/Config/ZeroAngle RL"=25.2
+    double "/Config/ZeroAngle RR"=-153.1
+
+    Competition Bot
+    [NetworkTables Storage 3.0]
+    double "/Config/CanCoder CanId FL"=50
+    double "/Config/CanCoder CanId FR"=49
+    double "/Config/CanCoder CanId RL"=59
+    double "/Config/CanCoder CanId RR"=40
+    double "/Config/DriveMotor CanId FL"=32
+    double "/Config/DriveMotor CanId FR"=28
+    double "/Config/DriveMotor CanId RL"=38
+    double "/Config/DriveMotor CanId RR"=21
+    double "/Config/Shooter CanId"=24
+    double "/Config/TurnMotor CanId FL"=30
+    double "/Config/TurnMotor CanId FR"=29
+    double "/Config/TurnMotor CanId RL"=39
+    double "/Config/TurnMotor CanId RR"=40
+    double "/Config/ZeroAngle FL"=92.5
+    double "/Config/ZeroAngle FR"=-3.39
+    double "/Config/ZeroAngle RL"=164
+    double "/Config/ZeroAngle RR"=-81.8
+    */
+}

--- a/src/main/java/frc/robot/Drivetrain.java
+++ b/src/main/java/frc/robot/Drivetrain.java
@@ -114,32 +114,32 @@ public class Drivetrain extends SubsystemBase {
         }
         //per corner constants
         constants[FL].Name = "SwerveDrive_FL";
-        constants[FL].DriveMotorId = 7;
-        constants[FL].TurnMotorId = 8;
-        constants[FL].CanCoderId = 3;
+        constants[FL].DriveMotorId = 32;
+        constants[FL].TurnMotorId = 30;
+        constants[FL].CanCoderId = 50;
         constants[FL].Location = new Translation2d(0.261, 0.261);
-        constants[FL].ZeroAngle = -6.1;
+        constants[FL].ZeroAngle = 92.5;
 
         constants[FR].Name = "SwerveDrive_FR";
-        constants[FR].DriveMotorId = 5;
-        constants[FR].TurnMotorId = 9;
-        constants[FR].CanCoderId = 0;
+        constants[FR].DriveMotorId = 28;
+        constants[FR].TurnMotorId = 29;
+        constants[FR].CanCoderId = 49;
         constants[FR].Location = new Translation2d(0.261, -0.261);
-        constants[FR].ZeroAngle = 47.9;
+        constants[FR].ZeroAngle = -3.39;
 
         constants[RL].Name = "SwerveDrive_RL";
-        constants[RL].DriveMotorId = 4;
-        constants[RL].TurnMotorId = 11;
-        constants[RL].CanCoderId = 1;
+        constants[RL].DriveMotorId = 38;
+        constants[RL].TurnMotorId = 39;
+        constants[RL].CanCoderId = 59;
         constants[RL].Location = new Translation2d(-0.261, 0.261);
-        constants[RL].ZeroAngle = 25.2;  
+        constants[RL].ZeroAngle = 164.0;  
 
         constants[RR].Name = "SwerveDrive_RR";
-        constants[RR].DriveMotorId = 6;
-        constants[RR].TurnMotorId = 10;
-        constants[RR].CanCoderId = 2;
+        constants[RR].DriveMotorId = 21;
+        constants[RR].TurnMotorId = 20;
+        constants[RR].CanCoderId = 40;
         constants[RR].Location = new Translation2d(-0.261, -0.261);
-        constants[RR].ZeroAngle = -153.1;
+        constants[RR].ZeroAngle = -81.8;
 
         //create the swerve modules
         for(int i=0; i<modules.length; i++) {

--- a/src/main/java/frc/robot/Drivetrain.java
+++ b/src/main/java/frc/robot/Drivetrain.java
@@ -89,6 +89,7 @@ public class Drivetrain extends SubsystemBase {
         //set defaults for all swerve moules
         for(int i=0; i<constants.length; i++) {
             constants[i] = new SwerveConstants();
+            constants[i].Id = (byte)i;
             constants[i].TurnMotor = DCMotor.getNeo550(1);
             constants[i].TurnMotorGearRatio = (12/1) * (64/12); //12:1 on the motor, 5.33 in the swerve
             constants[i].DriveMotor = DCMotor.getFalcon500(1);
@@ -114,32 +115,16 @@ public class Drivetrain extends SubsystemBase {
         }
         //per corner constants
         constants[FL].Name = "SwerveDrive_FL";
-        constants[FL].DriveMotorId = 32;
-        constants[FL].TurnMotorId = 30;
-        constants[FL].CanCoderId = 50;
         constants[FL].Location = new Translation2d(0.261, 0.261);
-        constants[FL].ZeroAngle = 92.5;
 
         constants[FR].Name = "SwerveDrive_FR";
-        constants[FR].DriveMotorId = 28;
-        constants[FR].TurnMotorId = 29;
-        constants[FR].CanCoderId = 49;
         constants[FR].Location = new Translation2d(0.261, -0.261);
-        constants[FR].ZeroAngle = -3.39;
 
         constants[RL].Name = "SwerveDrive_RL";
-        constants[RL].DriveMotorId = 38;
-        constants[RL].TurnMotorId = 39;
-        constants[RL].CanCoderId = 59;
-        constants[RL].Location = new Translation2d(-0.261, 0.261);
-        constants[RL].ZeroAngle = 164.0;  
+        constants[RL].Location = new Translation2d(-0.261, 0.261); 
 
         constants[RR].Name = "SwerveDrive_RR";
-        constants[RR].DriveMotorId = 21;
-        constants[RR].TurnMotorId = 20;
-        constants[RR].CanCoderId = 40;
         constants[RR].Location = new Translation2d(-0.261, -0.261);
-        constants[RR].ZeroAngle = -81.8;
 
         //create the swerve modules
         for(int i=0; i<modules.length; i++) {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -14,11 +14,10 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.commands.*;
-import frc.robot.ShooterConstants;
 
 public class Robot extends TimedRobot {
     private final XboxController controller = new XboxController(0);
-    private final Drivetrain swerve = new Drivetrain();
+    private Drivetrain swerve;
     private final Pi pi = new Pi();
     private Shooter shooter;
 
@@ -32,16 +31,17 @@ public class Robot extends TimedRobot {
     private static final String option6 = "Option6";
     private String m_autoSelected;
     private final SendableChooser<String> m_chooser = new SendableChooser<>();
-    DriveStickSlew driveStickSlew = new DriveStickSlew(swerve, controller);
 
     @Override
     public void robotInit() {
+        Configuration.SetPersistentKeys();
         GitVersion vers = GitVersion.loadVersion();
         vers.printVersions();
         
         ShooterConstants.LoadConstants();
         shooter = new Shooter(pi);
 
+        swerve = new Drivetrain();
         CommandScheduler.getInstance().registerSubsystem(swerve);
         swerve.setDefaultCommand(new DriveStickSlew(swerve, controller));
         shooter.setDefaultCommand(new NoShoot(shooter));

--- a/src/main/java/frc/robot/Shooter.java
+++ b/src/main/java/frc/robot/Shooter.java
@@ -6,7 +6,6 @@ import com.ctre.phoenix.motorcontrol.can.TalonFX;
 import com.ctre.phoenix.motorcontrol.can.TalonFXConfiguration;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 
-import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
@@ -31,8 +30,8 @@ public class Shooter extends SubsystemBase
     public Shooter(Pi pi) {
         this.pi = pi;
         isHomed = false;
-        // Example usage of a TalonSRX motor controller
-        shooterFx = new TalonFX(24); // creates a new TalonSRX with ID 0
+        
+        shooterFx = new TalonFX(Configuration.GetShooterId()); 
         shooterFx.setNeutralMode(NeutralMode.Coast);
         shooterFx.setInverted(false);
         // hoodMotor = new TalonSRX(2);

--- a/src/main/java/frc/robot/Shooter.java
+++ b/src/main/java/frc/robot/Shooter.java
@@ -32,7 +32,7 @@ public class Shooter extends SubsystemBase
         this.pi = pi;
         isHomed = false;
         // Example usage of a TalonSRX motor controller
-        shooterFx = new TalonFX(0); // creates a new TalonSRX with ID 0
+        shooterFx = new TalonFX(24); // creates a new TalonSRX with ID 0
         shooterFx.setNeutralMode(NeutralMode.Coast);
         shooterFx.setInverted(false);
         // hoodMotor = new TalonSRX(2);

--- a/src/main/java/frc/robot/SwerveConstants.java
+++ b/src/main/java/frc/robot/SwerveConstants.java
@@ -5,11 +5,8 @@ import edu.wpi.first.math.system.plant.DCMotor;
 
 public class SwerveConstants {
     public String Name;
-    public int DriveMotorId;
-    public int TurnMotorId;
-    public int CanCoderId;
     public Translation2d Location;
-    public double ZeroAngle;
+    public byte Id;
     
     public DCMotor TurnMotor;
     public double  TurnMotorGearRatio;

--- a/src/main/java/frc/robot/SwerveModule.java
+++ b/src/main/java/frc/robot/SwerveModule.java
@@ -58,6 +58,7 @@ public class SwerveModule {
     private EncoderSim driveEncoderSim;
     private EncoderSim turnEncoderSim;
     private static int encoderIndex = 0;
+    private double zeroAngle;
 
     /**
      * Constructs a SwerveModule.
@@ -68,8 +69,8 @@ public class SwerveModule {
      */
     public SwerveModule(SwerveConstants cornerConstants) {
         constants = cornerConstants;
-        driveMotor = new WPI_TalonFX(constants.DriveMotorId);
-        turningMotor = new CANSparkMax(constants.TurnMotorId, MotorType.kBrushless);
+        driveMotor = new WPI_TalonFX(Configuration.GetDriveMotorId(constants.Id));
+        turningMotor = new CANSparkMax(Configuration.GetTurnMotorId(constants.Id), MotorType.kBrushless);
         turningEncoder = turningMotor.getEncoder();
         turningEncoder.setPositionConversionFactor(6.82);
         driveMotor.setNeutralMode(NeutralMode.Brake);
@@ -89,9 +90,11 @@ public class SwerveModule {
         pidController.setOutputRange(min, max);
         */
 
-        absEncoder = new CANCoder(constants.CanCoderId);
+        absEncoder = new CANCoder(Configuration.GetCanCoderId(constants.Id));
         absEncoder.setPositionToAbsolute();
         absEncoder.configAbsoluteSensorRange(AbsoluteSensorRange.Signed_PlusMinus180, 0);
+        zeroAngle = Configuration.GetZeroAngle(constants.Id);
+
         // Limit the PID Controller's input range between -pi and pi and set the input
         // to be continuous.
         turningPIDController.enableContinuousInput(-Math.PI, Math.PI);
@@ -151,7 +154,7 @@ public class SwerveModule {
 
     public double getAbsoluteAngle() {
         if(Robot.isReal()) {
-            return -absEncoder.getAbsolutePosition() + constants.ZeroAngle;
+            return -absEncoder.getAbsolutePosition() + zeroAngle;
         } else {
             return turnEncoderSim.getDistance();
         }


### PR DESCRIPTION
New robot means new drive IDs...

This change does break both bots (simulation is fine), but there is a fix.  If you go to NetworkTables (OutlineViewer works best), and the values that need to be put in /Config/ are at the bottom of Configuration.java.  This will need to be done once per robot, but should stay in the Rio for the rest of the season and not need updates.  If we have to swap out a swerve corner also, it will be easy to update NetworkTables and go.  

Once the table is updated, a Rio reset is needed, as we read config at Init (mainly for throughput, although they shouldn't change while driving either).  I will update the documentation also on how to configure the robots.