### PR TITLE
Fixing the swerve overheating issue

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,8 +4,11 @@
 
 package frc.robot;
 
+import javax.xml.crypto.Data;
+
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
@@ -79,6 +82,7 @@ public class Robot extends TimedRobot {
         Configuration.SetPersistentKeys();
         GitVersion vers = GitVersion.loadVersion();
         vers.printVersions();
+        DataLogManager.start();
 
         ShooterConstants.LoadConstants();
         shooter = new Shooter(pi, driverController, operatorController, colorSensor, ingestor);

--- a/src/main/java/frc/robot/SwerveModule.java
+++ b/src/main/java/frc/robot/SwerveModule.java
@@ -191,12 +191,19 @@ public class SwerveModule {
         // oldTurnAngle = Math.toRadians(getAbsoluteAngle());
 
         turnVoltCommand = -turnOutput;
-        DataLogManager.log(constants.Name + " Turn volt command: " + turnVoltCommand);
+        //DataLogManager.log(constants.Name + " Turn volt command: " + turnVoltCommand);
         driveVoltCommand = driveOutput + driveFeedforward;
 
+        if (driveVoltCommand <= 0.01) {
+            turnVoltCommand = 0;
+        }
+        
+        //DataLogManager.log(constants.Name + " Drive volt command: " + driveVoltCommand);
+        
         driveMotor.setVoltage(driveVoltCommand);
         turningMotor.setVoltage(turnVoltCommand);
 
+        
         /*
          * TODO: use hardware control of motor control instead of SW
          * //set the motor to 10 revolutions. We should divide the encoder to degrees
@@ -237,6 +244,7 @@ public class SwerveModule {
         SmartDashboard.putNumber(constants.Name + "/absEncoderRaw", absEncoder.getAbsolutePosition());
         SmartDashboard.putNumber(constants.Name + "/turnEncoderRaw", turningEncoder.getPosition());
         SmartDashboard.putNumber(constants.Name + "/turnVoltCommand", turnVoltCommand);
+        SmartDashboard.putNumber(constants.Name + "/driveVoltCommand", driveVoltCommand);
     }
 
     public void setBrakeMode(boolean brake) {

--- a/src/main/java/frc/robot/SwerveModule.java
+++ b/src/main/java/frc/robot/SwerveModule.java
@@ -15,6 +15,7 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMax.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
+import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.math.controller.PIDController;
@@ -54,6 +55,7 @@ public class SwerveModule {
     private double turnVoltCommand;
     private double driveVoltCommand;
     private SwerveConstants constants;
+    private double oldTurnAngle = 0.0;
 
     // Using FlywheelSim as a stand-in for a simple motor
     private FlywheelSim m_turnMotorSim;
@@ -180,10 +182,16 @@ public class SwerveModule {
         final double driveFeedforward = driveFeedForward.calculate(state.speedMetersPerSecond);
 
         // Calculate the turning motor output from the turning PID controller.
+        // if(oldTurnAngle == 0) {
+        //     oldTurnAngle = Math.toRadians(getAbsoluteAngle());
+        // }
+        // double newTurnAngle = (1 - 0.4) * oldTurnAngle + 0.4 * Math.toRadians(getAbsoluteAngle());
         final double turnOutput = turningPIDController.calculate(Math.toRadians(getAbsoluteAngle()),
                 state.angle.getRadians());
+        // oldTurnAngle = Math.toRadians(getAbsoluteAngle());
 
         turnVoltCommand = -turnOutput;
+        DataLogManager.log(constants.Name + " Turn volt command: " + turnVoltCommand);
         driveVoltCommand = driveOutput + driveFeedforward;
 
         driveMotor.setVoltage(driveVoltCommand);
@@ -228,6 +236,7 @@ public class SwerveModule {
         SmartDashboard.putNumber(constants.Name + "/absEncoderZeroed", getAbsoluteAngle());
         SmartDashboard.putNumber(constants.Name + "/absEncoderRaw", absEncoder.getAbsolutePosition());
         SmartDashboard.putNumber(constants.Name + "/turnEncoderRaw", turningEncoder.getPosition());
+        SmartDashboard.putNumber(constants.Name + "/turnVoltCommand", turnVoltCommand);
     }
 
     public void setBrakeMode(boolean brake) {

--- a/src/main/java/frc/robot/SwerveModule.java
+++ b/src/main/java/frc/robot/SwerveModule.java
@@ -194,7 +194,7 @@ public class SwerveModule {
         //DataLogManager.log(constants.Name + " Turn volt command: " + turnVoltCommand);
         driveVoltCommand = driveOutput + driveFeedforward;
 
-        if (driveVoltCommand <= 0.01) {
+        if (Math.abs(driveVoltCommand) <= 0.01) {
             turnVoltCommand = 0;
         }
         


### PR DESCRIPTION
If there's only a tiny command to the drive motor, set turn motor command to zero so it isn't constantly getting commands and overheating.